### PR TITLE
Use log::info! instead of println!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "bitcoin",
  "clap",
  "crossbeam-channel",
+ "log",
  "postcard",
  "rand",
  "rustc-hash",
@@ -346,6 +347,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "num_cpus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0.88"
 threadpool = "1.8.1"
 rustc-hash = "2.0.0"
 crossbeam-channel = "0.5.13"
+log = "0.4.22"
 
 # Could make the following deps into a feature
 postcard = { version = "1.0.10", features = ["use-std"] }

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -93,6 +93,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
+use log::info;
 use threadpool::ThreadPool;
 use crate::HeaderParser;
 
@@ -225,8 +226,8 @@ fn increment_log(num_parsed: &Arc<AtomicUsize>, start: Instant, log_at: usize) {
 
     if num % log_at == 0 {
         let elapsed = (Instant::now() - start).as_secs();
-        print!("{}K blocks parsed,", num / 1000);
-        println!(" {}m{}s elapsed", elapsed / 60, elapsed % 60);
+        info!("{}K blocks parsed,", num / 1000);
+        info!(" {}m{}s elapsed", elapsed / 60, elapsed % 60);
     }
 }
 


### PR DESCRIPTION
It's not recommended to use `println!` directly in libraries. It outputs extra unneeded info out.

Instead, the [`log`](https://crates.io/crates/log) crate may help. Just use these logging macros and the end user can choose logging implementation libraries (e.g. [`fern`](https://crates.io/crates/fern)). For apps that use this crate, if no logging implementation libraries are enabled, `log::info!` will do nothing.