### PR TITLE
improved some error messages

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -3,6 +3,7 @@
 
 use crate::xor::{XorReader, XOR_MASK_LEN};
 use anyhow::bail;
+use anyhow::Context;
 use anyhow::Result;
 use bitcoin::block::Header;
 use bitcoin::consensus::Decodable;
@@ -87,7 +88,10 @@ impl HeaderParser {
         xor_mask: Option<[u8; XOR_MASK_LEN]>,
     ) -> Result<Vec<ParsedHeader>> {
         let buffer_size = PRE_HEADER_SIZE + Header::SIZE;
-        let reader = XorReader::new(File::open(&path)?, xor_mask);
+        let reader = XorReader::new(
+            File::open(&path).context(path.display().to_string())?,
+            xor_mask,
+        );
         let mut reader = BufReader::with_capacity(buffer_size, reader);
 
         let mut offset = 0;
@@ -117,7 +121,7 @@ impl HeaderParser {
 
     /// Returns the list of all BLK files in the dir
     fn blk_files(dir: &str) -> Result<Vec<PathBuf>> {
-        let read_dir = fs::read_dir(Path::new(&dir))?;
+        let read_dir = fs::read_dir(Path::new(&dir)).context(dir.to_string())?;
         let mut files = vec![];
 
         for file in read_dir {

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -89,7 +89,7 @@ impl HeaderParser {
     ) -> Result<Vec<ParsedHeader>> {
         let buffer_size = PRE_HEADER_SIZE + Header::SIZE;
         let reader = XorReader::new(
-            File::open(&path).context(path.display().to_string())?,
+            File::open(&path).context(format!("Could not open: {}", path.display().to_string()))?,
             xor_mask,
         );
         let mut reader = BufReader::with_capacity(buffer_size, reader);

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -79,6 +79,9 @@ impl HeaderParser {
         }
         let ordered = Self::order_headers(locations);
         info!("Finished reading {} headers", ordered.len());
+        if ordered.len() == 0 {
+            bail!("Read 0 Headers. Is blk000000.dat missing?");
+        }
         Ok(ordered)
     }
 


### PR DESCRIPTION
I tried to improve some logging messages in case of errors.
When one of the BLK files couldn't be read due to permissions it used to say:
```
thread 'main' panicked at src/main.rs:172:54:
called `Result::unwrap()` on an `Err` value: Permission denied (os error 13)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
It will now say:
```
thread 'main' panicked at src/main.rs:172:54:
called `Result::unwrap()` on an `Err` value: Could not open: /.bitcoin/blocks/blk00002.dat

Caused by:
    Permission denied (os error 13)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
The same if we pointed it do a non existent directory.


When blk00000.dat is missing, it would read the headers of the remaining blocks, but after ordering the headers, 0 headers would be left and header parsing would successfully return a empty vec.
This caused a overflow error in block parsing:
```
thread 'main' panicked at src/blocks.rs:114:47:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Instead if there are 0 headers left after ordering, it will immediately fail, and suggest that a blk file might be missing:
```
thread 'main' panicked at src/main.rs:172:54:
called `Result::unwrap()` on an `Err` value: Read 0 Headers. Is blk000000.dat missing?
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```